### PR TITLE
Refactor out pypng, use rasterio to save pngs with projection information, adds python-fire for cli

### DIFF
--- a/crism.py
+++ b/crism.py
@@ -18,7 +18,7 @@ class ColourSystem:
     its three primary illuminants and its "white point"."""
 
     # The CIE colour matching function for 380 - 780 nm in 5 nm intervals
-    cmf = np.loadtxt('mtrdr-cie-cmf.txt', usecols=(1,2,3))
+    cmf = np.loadtxt('cie-cmf.txt', usecols=(1,2,3))
 
     def __init__(self, red, green, blue, white):
         """Initialise the ColourSystem object.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click-plugins==1.1.1
 cligj==0.7.1
 numpy==1.20.2
 pyparsing==2.4.7
-pypng==0.0.20
 rasterio==1.2.2
 snuggs==1.4.7
 spectres==2.1.1
+fire


### PR DESCRIPTION
this PR removes pypng as a dependency and uses rasterio instead directly to save pngs with associated CRS information in aux files that can be loaded into gis programs. Also gets rid of ISIS pre-processing step as the PDS driver in GDAL/rasterio works. 

adds python-fire to make a more interesting, but maybe not better CLI. just run `python crism.py` to use it. Improvement is marginal so I'll probably remove it.

maybe give this a try before merging as I don't know if I totally got this right yet as I didn't make a baseline to compare against prior to pushing 